### PR TITLE
Use @rustls-benchmarking as the app's name

### DIFF
--- a/ci-bench-runner/src/test/mod.rs
+++ b/ci-bench-runner/src/test/mod.rs
@@ -186,7 +186,7 @@ async fn test_issue_comment_unauthorized_user() {
 
     // Post the webhook event
     let client = reqwest::Client::default();
-    let event = webhook::comment("@rustls-bench bench", "created", "NONE");
+    let event = webhook::comment("@rustls-benchmarking bench", "created", "NONE");
     post_webhook(
         &client,
         &server.base_url,
@@ -211,7 +211,7 @@ async fn test_issue_comment_edited() {
 
     // Post the webhook event
     let client = reqwest::Client::default();
-    let event = webhook::comment("@rustls-bench bench", "edit", "OWNER");
+    let event = webhook::comment("@rustls-benchmarking bench", "edit", "OWNER");
     post_webhook(
         &client,
         &server.base_url,
@@ -239,7 +239,7 @@ async fn test_issue_comment_happy_path() {
 
     // Post the webhook event
     let client = reqwest::Client::default();
-    let event = webhook::comment("@rustls-bench bench", "created", "OWNER");
+    let event = webhook::comment("@rustls-benchmarking bench", "created", "OWNER");
     post_webhook(
         &client,
         &server.base_url,

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,8 @@ The following features are supported:
   For security, comparison bench runs are only triggered in the following scenarios:
   - A PR is created or updated and the head branch lives in the rustls repository.
   - A maintainer leaves a GitHub review approving the PR.
-  - A maintainer posts a comment to the PR including `@rustls-bench bench` as part of the body. This
-    can be used as a fallback mechanism when the triggers mentioned above are not enough.
+  - A maintainer posts a comment to the PR including `@rustls-benchmarking bench` as part of the
+    body. This can be used as a fallback mechanism when the triggers mentioned above are not enough.
 - Report comparison results in a comment to the relevant PR, reusing the same comment when new
   results are available.
 


### PR DESCRIPTION
With this change, the name matches the real name of the app that is currently installed on the rustls repo.

@cpu I've chosen to keep the name hardcoded, even though it would be possible to obtain the application's name dynamically using the GitHub API. We aren't planning to deploy multiple instances of this, with different names each, so I'd rather go with this pragmatic choice instead of making things dynamic. If you disagree, let me know and we can discuss (your judgement weights heavier than mine here, IMO, because you are going to actually maintain this the coming months).