### PR TITLE
fix: replace `vergen` by directly running git

### DIFF
--- a/ci-bench-runner/Cargo.lock
+++ b/ci-bench-runner/Cargo.lock
@@ -414,7 +414,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "vergen",
  "wiremock",
 ]
 
@@ -1462,15 +1461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -2794,8 +2784,6 @@ checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -3196,17 +3184,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "8.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1290fd64cc4e7d3c9b07d7f333ce0ce0007253e32870e632624835cc80b83939"
-dependencies = [
- "anyhow",
- "rustversion",
- "time",
-]
 
 [[package]]
 name = "version_check"

--- a/ci-bench-runner/Cargo.toml
+++ b/ci-bench-runner/Cargo.toml
@@ -31,6 +31,3 @@ uuid = { version = "1.4.1", features = ["v4", "serde"] }
 ctor = "0.2.5"
 reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls-webpki-roots"] }
 wiremock = "0.5.19"
-
-[build-dependencies]
-vergen = { version = "8.2.6", features = ["git", "gitcl"] }

--- a/ci-bench-runner/build.rs
+++ b/ci-bench-runner/build.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // In some cases if new migrations are added without accompanying Rust src changes
     // `cargo build` isn't smart enough to detect the need for recompilation to pick up
@@ -5,7 +7,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // See <https://docs.rs/sqlx/latest/sqlx/macro.migrate.html#triggering-recompilation-on-migration-changes>
     println!("cargo:rerun-if-changed=migrations");
 
-    // Expose git-related information through environment variables at compile-time
-    vergen::EmitBuilder::builder().all_git().emit()?;
+    // Trigger recompilation if the repository's head changed, to make sure the commit information
+    // embedded in the binary is up-to-date
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    // Expose git head information through environment variables at compile-time, so it can be
+    // embedded in the binary through the `env!` macro
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output()?;
+    let git_sha = String::from_utf8(output.stdout)?;
+    println!("cargo:rustc-env=GIT_HEAD_SHA={}", git_sha);
+
+    let output = Command::new("git")
+        .args(["show-branch", "--no-name", "HEAD"])
+        .output()?;
+    let git_commit_message = String::from_utf8(output.stdout)?;
+    println!("cargo:rustc-env=GIT_HEAD_COMMIT_MESSAGE={git_commit_message}");
+
     Ok(())
 }

--- a/ci-bench-runner/src/lib.rs
+++ b/ci-bench-runner/src/lib.rs
@@ -136,8 +136,8 @@ pub async fn server(
 /// Returns git commit information about the binary that is currently deployed
 async fn get_server_info() -> Json<serde_json::Value> {
     Json(json!({
-        "git_commit_sha": env!("VERGEN_GIT_SHA").to_string(),
-        "git_commit_message": env!("VERGEN_GIT_COMMIT_MESSAGE").to_string(),
+        "git_commit_sha": env!("GIT_HEAD_SHA").to_string(),
+        "git_commit_message": env!("GIT_HEAD_COMMIT_MESSAGE").to_string(),
     }))
 }
 


### PR DESCRIPTION
For some reason, `vergen` was unable to find the git binary when building inside Ansible. Running git directly fixes the problem... and we also have one dependency less! 🎉

Fixes #27 