### PR TITLE
ansible: run certificate renewal cronjob as root

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -38,6 +38,8 @@
     state: reloaded
     enabled: true
 - name: Setup cronjob for certificate renewal
+  become: true
+  become_user: root
   ansible.builtin.cron:
     name: certbot-renewal
     job: /bin/bash -lc 'certbot -q renew'


### PR DESCRIPTION
Otherwise the job will be properly registered, but every run will fail due to lack of permissions.