### PR TITLE
cachegrind: ignore leading path to the benchmarked rustls checkout

### DIFF
--- a/ci-bench-runner/src/job/bench_pr.rs
+++ b/ci-bench-runner/src/job/bench_pr.rs
@@ -628,6 +628,8 @@ pub fn cachegrind_diff(job_output_path: &Path, scenario: &str) -> anyhow::Result
         // _ZN9hashbrown3raw21RawTable$LT$T$C$A$GT$14reserve_rehash17hc60392f3f3eac4b2E.llvm.9716880419886440089 ->
         // _ZN9hashbrown3raw21RawTable$LT$T$C$A$GT$14reserve_rehashE
         .arg("--mod-funcname=s/17h[0-9a-f]+E\\.llvm\\.\\d+/E/")
+        // remove the leading path, which is unique for each checkout of the repository (we replace it by `rustls`)
+        .arg("--mod-filename=s/.+\\/(target\\/release\\/build.+)/rustls\\/\\1/")
         .arg(baseline_cachegrind_file_path)
         .arg(candidate_cachegrind_file_path)
         .stdout(Stdio::from(diff_file))


### PR DESCRIPTION
For each PR benchmark we create two checkouts of the rustls repository, each one in its own directory (e.g. `/tmp/.tmpZE2KDR` and `/tmp/.tmpq8vPPQ`). As a consequence, when comparing the cachegrind output the diff tool fails to correlate the functions of both runs. The result is a totally useless diff, where all instructions from the baseline are considered to have disappeared and all instructions from the candidate to have appeared (for an example, see https://bench.rustls.dev/comparisons/371463d8129f4f0541e38063358ec2ad4428a44a:453cf7968b251b22db5bcadebefe3ea37125b630/cachegrind-diff/handshake_tickets_aws_lc_rs_1.2_rsa_aes_server)

This commit tells cachegrind to ignore the leading path (everything up to `target/release/build`), restoring the ability to track individual rustls functions.